### PR TITLE
feat: Default posts to published and redact emails

### DIFF
--- a/src/handlers/email.ts
+++ b/src/handlers/email.ts
@@ -24,7 +24,7 @@ export async function handleEmail(message: EmailMessage, env: Env) {
 			html: email.html || null,
 			text: email.text || null,
 			publishedAt,
-			isPublished: false, // Posts are drafts by default
+			isPublished: true, // Posts are published by default
 		};
 
 		// Apply rules to get initial tags
@@ -49,7 +49,7 @@ export async function handleEmail(message: EmailMessage, env: Env) {
 			subject: finalPost.subject,
 			tags: finalPost.tags,
 			publishedAt: finalPost.publishedAt,
-			isPublished: finalPost.isPublished,
+			isPublished: finalPost.isPublished, // This will now be true from initialPostData
 		};
 		
 		await Promise.all([postStorageStub.fetch('http://durable-object/create', { method: 'POST', body: JSON.stringify(finalPost) }), indexStub.fetch('http://durable-object/add', { method: 'POST', body: JSON.stringify(postSummary) })]);

--- a/src/services/redact.ts
+++ b/src/services/redact.ts
@@ -1,0 +1,24 @@
+// src/services/redact.ts
+
+/**
+ * Replaces all occurrences of email addresses in a given text with "[REDACTED]".
+ *
+ * This function uses a regular expression to identify email addresses.
+ * The regex aims to cover common email formats but might not catch all edge cases.
+ *
+ * @param text The input string that may contain email addresses.
+ * @returns The string with email addresses redacted.
+ */
+export function redactEmails(text: string | null | undefined): string {
+	if (!text) {
+		return '';
+	}
+	// Regular expression to match common email patterns.
+	// It looks for:
+	// - username part: characters (letters, numbers, dots, hyphens, underscores, plus signs)
+	// - @ symbol
+	// - domain part: characters (letters, numbers, dots, hyphens)
+	// - top-level domain: dot followed by 2 or more letters
+	const emailRegex = /([a-zA-Z0-9._%+-]+)@([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/g;
+	return text.replace(emailRegex, '[REDACTED]');
+}

--- a/src/views/pages.ts
+++ b/src/views/pages.ts
@@ -1,6 +1,7 @@
 // src/views/pages.ts
 import { Env, Post, PostSummary } from '../types';
 import { renderLayout } from './layout';
+import { redactEmails } from '../services/redact';
 
 const formatDate = (dateString: string) => new Date(dateString).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
 
@@ -28,17 +29,22 @@ export const renderBlogIndex = (posts: PostSummary[], env: Env): string => {
 };
 
 export const renderPostPage = (post: Post, env: Env): string => {
+	const displayAuthor = post.from.name || redactEmails(post.from.address);
+	const redactedSubject = redactEmails(post.subject);
+	const redactedHtml = redactEmails(post.html);
+	const redactedText = redactEmails(post.text);
+
 	const content = `
         <article>
-            <h1>${post.subject}</h1>
+            <h1>${redactedSubject}</h1>
             <div class="post-meta">
-                <span>By ${post.from.name || post.from.address} on ${formatDate(post.publishedAt)}</span>
+                <span>By ${displayAuthor} on ${formatDate(post.publishedAt)}</span>
                  ${post.tags.map((tag) => `<span class="tag">${tag}</span>`).join('')}
             </div>
             <div class="post-content">
-                ${post.html || `<p>${post.text?.replace(/\n/g, '<br>')}</p>`}
+                ${redactedHtml || `<p>${redactedText?.replace(/\n/g, '<br>')}</p>`}
             </div>
         </article>
     `;
-	return renderLayout(post.subject, content, env);
+	return renderLayout(redactedSubject, content, env);
 };

--- a/src/views/rss.ts
+++ b/src/views/rss.ts
@@ -1,19 +1,22 @@
 // src/views/rss.ts
 import { Env, PostSummary } from '../types';
+import { redactEmails } from '../services/redact';
 
 export const generateRss = (posts: PostSummary[], env: Env): string => {
 	const items = posts
-		.map(
-			(post) => `
+		.map((post) => {
+			const redactedSubject = redactEmails(post.subject);
+			const redactedDescription = redactEmails(`A post titled "${post.subject}"`); // Explicitly redact description content
+			return `
         <item>
-            <title><![CDATA[${post.subject}]]></title>
+            <title><![CDATA[${redactedSubject}]]></title>
             <link>${env.BLOG_URL}/post/${post.id}</link>
             <guid isPermaLink="true">${env.BLOG_URL}/post/${post.id}</guid>
             <pubDate>${new Date(post.publishedAt).toUTCString()}</pubDate>
-            <description><![CDATA[A post titled "${post.subject}"]]></description>
+            <description><![CDATA[${redactedDescription}]]></description>
         </item>
-    `,
-		)
+    `;
+		})
 		.join('');
 
 	return `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
- Change default behavior for new posts to be published instead of draft.
- Implement email address redaction in blog post views (sender, subject, body) and RSS feeds (title, description) to protect personal data.
- Added a utility function to handle email redaction using regex.