### PR TITLE
Fix admin login API authentication and update tests

### DIFF
--- a/__mocks__/cloudflare/workers.js
+++ b/__mocks__/cloudflare/workers.js
@@ -1,0 +1,23 @@
+// __mocks__/cloudflare/workers.js
+
+// Mock DurableObject class
+export class DurableObject {
+  constructor(state, env) {
+    this.state = state;
+    this.env = env;
+  }
+
+  // Add any methods that are called on DurableObject instances in your tests
+  // For example, if your DOs use this.state.storage.get(), you might need to mock that.
+  // For basic instantiation, this constructor might be enough.
+}
+
+// Mock any other exports from 'cloudflare:workers' that your code might use.
+// For example, if you use `fetchMock` or other utilities:
+// export const fetchMock = vi.fn();
+
+// If there are other specific named exports, mock them as needed:
+// export const SomeOtherExport = {};
+
+// Default export if needed (less common for 'cloudflare:workers' which usually has named exports)
+// export default {};

--- a/src/handlers/admin.test.ts
+++ b/src/handlers/admin.test.ts
@@ -1,9 +1,11 @@
 import { Hono } from 'hono';
-import adminRoutes from './admin'; // Assuming admin.ts exports the Hono app instance
+// Import the main application instance (named export)
+import { app } from '../index';
 import type { Env } from '../types';
 
+// app is already correctly typed Hono<{ Bindings: Env }> due to its origin
+
 describe('Admin Handler Tests', () => {
-	let app: Hono<{ Bindings: Env }>;
 	const mockEnv = {
 		ADMIN_TOKEN: 'test-secret-token',
 		POST_INDEX: {
@@ -20,29 +22,31 @@ describe('Admin Handler Tests', () => {
 			delete: async () => {},
 			get: async () => null,
 		},
-		// Add other necessary mocks for Env if admin routes use them directly
+		// Add other necessary mocks for Env
 	} as Env;
 
 	beforeEach(() => {
-		// Re-initialize app before each test to ensure clean state
-		// Pass the mock Env to the Hono app constructor if it expects it
-		// For this example, adminRoutes is an instance, so we bind env to context
-		app = new Hono<{ Bindings: Env }>();
-		app.use('*', (c, next) => {
-			c.env = mockEnv;
-			return next();
-		});
-		app.route('/api/admin', adminRoutes); // Mount the admin routes
+		// Bind the mock environment to the context for each request
+        // Hono's architecture means middleware in index.ts will handle this if app is the real instance
+        // For testing, we ensure 'c.env' is available for handlers if they access it directly.
+        // However, the bearerAuth in index.ts will use c.env.ADMIN_TOKEN.
+        // We need to ensure that our test runner provides this 'env' to Hono's context.
+        // Vitest/Hono typically handles this by passing env to `app.request`.
+        // The structure below assumes `app.request` will make `mockEnv` available.
 	});
 
 	// --- Test /api/admin/login ---
 	describe('POST /api/admin/login', () => {
 		it('should login successfully with a correct token', async () => {
-			const res = await app.request('/api/admin/login', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ token: 'test-secret-token' }),
-			});
+			const res = await app.request(
+				'/api/admin/login',
+				{
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ token: 'test-secret-token' }),
+				},
+				mockEnv
+			);
 			expect(res.status).toBe(200);
 			const body = await res.json();
 			expect(body.success).toBe(true);
@@ -50,11 +54,15 @@ describe('Admin Handler Tests', () => {
 		});
 
 		it('should fail login with an incorrect token', async () => {
-			const res = await app.request('/api/admin/login', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ token: 'wrong-token' }),
-			});
+			const res = await app.request(
+				'/api/admin/login',
+				{
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ token: 'wrong-token' }),
+				},
+				mockEnv
+			);
 			expect(res.status).toBe(401);
 			const body = await res.json();
 			expect(body.success).toBe(false);
@@ -62,22 +70,30 @@ describe('Admin Handler Tests', () => {
 		});
 
 		it('should fail login with no token in body', async () => {
-			const res = await app.request('/api/admin/login', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({}),
-			});
+			const res = await app.request(
+				'/api/admin/login',
+				{
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({}),
+				},
+				mockEnv
+			);
 			expect(res.status).toBe(401); // or 400 depending on implementation
 			const body = await res.json();
 			expect(body.success).toBe(false);
 		});
 
         it('should fail login with malformed JSON body', async () => {
-			const res = await app.request('/api/admin/login', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: 'not-json',
-			});
+			const res = await app.request(
+				'/api/admin/login',
+				{
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: 'not-json',
+				},
+				mockEnv
+			);
 			expect(res.status).toBe(400);
 			const body = await res.json();
 			expect(body.success).toBe(false);
@@ -88,34 +104,46 @@ describe('Admin Handler Tests', () => {
 	// --- Test a protected route, e.g., /api/admin/posts ---
 	describe('GET /api/admin/posts (Protected Route)', () => {
 		it('should access successfully with a correct Bearer token', async () => {
-			const res = await app.request('/api/admin/posts', {
-				headers: { Authorization: `Bearer test-secret-token` },
-			});
+			const res = await app.request(
+				'/api/admin/posts',
+				{
+					headers: { Authorization: `Bearer test-secret-token` },
+				},
+				mockEnv
+			);
 			expect(res.status).toBe(200);
 			// Further checks on the body can be added if needed
 			// For example, expect(await res.json()).toEqual([]);
 		});
 
 		it('should fail with an incorrect Bearer token', async () => {
-			const res = await app.request('/api/admin/posts', {
-				headers: { Authorization: `Bearer wrong-token` },
-			});
+			const res = await app.request(
+				'/api/admin/posts',
+				{
+					headers: { Authorization: `Bearer wrong-token` },
+				},
+				mockEnv
+			);
 			expect(res.status).toBe(401); // Unauthorized
             const text = await res.text();
             expect(text).toContain("Unauthorized"); // Hono's default bearer auth response
 		});
 
 		it('should fail with no Authorization header', async () => {
-			const res = await app.request('/api/admin/posts');
+			const res = await app.request('/api/admin/posts', undefined, mockEnv);
 			expect(res.status).toBe(401); // Unauthorized
             const text = await res.text();
             expect(text).toContain("Unauthorized");
 		});
 
         it('should fail with malformed Authorization header', async () => {
-			const res = await app.request('/api/admin/posts', {
-                headers: { Authorization: `Basic some-credentials`}, // Wrong scheme
-            });
+			const res = await app.request(
+				'/api/admin/posts',
+				{
+					headers: { Authorization: `Basic some-credentials` }, // Wrong scheme
+				},
+				mockEnv
+			);
 			expect(res.status).toBe(400); // Hono bearerAuth middleware returns 400 for malformed Authorization header
             const text = await res.text();
             expect(text).toContain("Bad Request"); // Or a more specific message if bearerAuth handles it

--- a/src/handlers/admin.ts
+++ b/src/handlers/admin.ts
@@ -7,18 +7,9 @@ import type { Env, Post, PostSummary, TaggingRule } from '../types';
 
 const adminRoutes = new Hono<{ Bindings: Env }>();
 
-// Auth middleware
-const authMiddleware = (env: Env) =>
-	bearerAuth({
-		verifyToken: async (token, c) => {
-			return token === env.ADMIN_TOKEN;
-		},
-		realm: 'Admin Area',
-		prefix: 'Bearer', // Ensure the prefix is Bearer
-	});
-
 // --- Auth ---
-// Login route is *not* protected by authMiddleware
+// Login route - now handled by the global middleware in src/index.ts,
+// but the route definition is still needed here.
 adminRoutes.post('/login', async (c) => {
 	try {
 		const { token } = await c.req.json<{ token: string }>();
@@ -35,14 +26,8 @@ adminRoutes.post('/login', async (c) => {
 	}
 });
 
-// Apply auth middleware to all subsequent routes in this group
-adminRoutes.use('*', async (c, next) => {
-	const mw = authMiddleware(c.env);
-	return mw(c, next);
-});
-
 // --- Posts API ---
-// These routes are now protected
+// These routes are protected by the middleware in src/index.ts
 
 // List all posts (published and drafts)
 adminRoutes.get('/posts', async (c) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,12 @@ const app = new Hono<{ Bindings: Env }>();
 
 // Secure all /api/admin/* routes with bearer token authentication
 const adminApi = app.basePath('/api/admin');
-adminApi.use('*', async (c, next) => {
+
+// Apply auth middleware to all admin routes *except* login
+adminApi.use('/*', async (c, next) => {
+	if (c.req.path === '/api/admin/login') {
+		return next();
+	}
 	const auth = bearerAuth({ token: c.env.ADMIN_TOKEN });
 	return auth(c, next);
 });
@@ -43,3 +48,5 @@ export default {
 	email: handleEmail,
 };
 
+// Export the app instance for testing purposes
+export { app };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,9 +23,16 @@ export default defineConfig({
   },
   // If you're using TypeScript, Vitest should pick up your tsconfig.json automatically.
   // You can specify tsconfig path if it's non-standard.
-  // resolve: {
-  //   alias: {
-  //      // Add any aliases you use in your project
-  //   }
-  // }
+  resolve: {
+    alias: [
+      {
+        find: /^cloudflare:(.+)$/,
+        // Ensure this path is correct relative to the project root
+        replacement: '/app/__mocks__/cloudflare/$1.js',
+      },
+      // You might need to add other aliases if there are other problematic imports
+      // For example, if 'hono/cloudflare-workers' causes issues, though it usually doesn't
+      // as Hono is designed to be environment-agnostic.
+    ],
+  },
 });


### PR DESCRIPTION
- Modified `src/index.ts` to exclude the `/api/admin/login` route from the global `bearerAuth` middleware. This allows unauthenticated access to the login endpoint.
- Removed redundant auth middleware from `src/handlers/admin.ts` to centralize authentication logic.
- Refactored `src/handlers/admin.test.ts` to test the main `app` instance from `src/index.ts`, ensuring global authentication middleware is applied during testing.
- Updated `vitest.config.ts` and added mocks to correctly handle Cloudflare-specific imports during tests.
- Ensured all tests pass after the changes.